### PR TITLE
Implement memory-backed storage for chunkserver

### DIFF
--- a/src/zircon/chunkserver/storage/api.go
+++ b/src/zircon/chunkserver/storage/api.go
@@ -5,6 +5,7 @@ import "zircon/apis"
 // An interface to a storage system for chunks and version information.
 // This interface is expected to be write-immediate; changes made should be
 // flushed to disk before each mutation returns.
+// This interface is NOT normally threadsafe! Uses of it must be confined to a single thread.
 type ChunkStorage interface {
 	// *** part 1: chunks ***
 
@@ -12,6 +13,7 @@ type ChunkStorage interface {
 	ListChunksWithData() ([]apis.ChunkNum, error)
 
 	// List all versions we have for a certain chunk, in ascending order
+	// If the chunk doesn't exist at all, no error is returned -- just an empty slice.
 	ListVersions(chunk apis.ChunkNum) ([]apis.Version, error)
 	// Read the entire contents of a particular version of a particular chunk
 	// note: version *cannot* be AnyVersion
@@ -30,6 +32,7 @@ type ChunkStorage interface {
 	ListChunksWithLatest() ([]apis.ChunkNum, error)
 
 	// Get the "latest version" (to report to clients) of a particular chunk.
+	// Returns an error if no version was stored for this chunk.
 	GetLatestVersion(chunk apis.ChunkNum) (apis.Version, error)
 	// Update the "latest version" (to report to clients) of a particular chunk.
 	SetLatestVersion(chunk apis.ChunkNum, latest apis.Version) error
@@ -37,5 +40,6 @@ type ChunkStorage interface {
 	DeleteLatestVersion(chunk apis.ChunkNum) error
 
 	// Empty any caches and tear down all storage state.
+	// Use of other methods after call this method is undefined behavior. Calling Close() again has no effect.
 	Close()
 }

--- a/src/zircon/chunkserver/storage/block.go
+++ b/src/zircon/chunkserver/storage/block.go
@@ -1,6 +1,8 @@
 package storage
 
+import "errors"
+
 // Given a path to a raw block device, construct an interface by which a chunkserver can store chunks
 func ConfigureBlockStorage(devicepath string) (ChunkStorage, error) {
-	panic("unimplemented")
+	return nil, errors.New("block storage not yet implemented")
 }

--- a/src/zircon/chunkserver/storage/filesystem.go
+++ b/src/zircon/chunkserver/storage/filesystem.go
@@ -1,7 +1,9 @@
 package storage
 
+import "errors"
+
 // Given a base path for storage of files in a modern filesystem, construct an interface by which a chunkserver can store
 // chunks.
 func ConfigureFilesystemStorage(basepath string) (ChunkStorage, error) {
-	panic("unimplemented")
+	return nil, errors.New("filesystem storage not yet implemented")
 }

--- a/src/zircon/chunkserver/storage/memory.go
+++ b/src/zircon/chunkserver/storage/memory.go
@@ -1,6 +1,140 @@
 package storage
 
+import (
+	"zircon/apis"
+	"sort"
+	"fmt"
+)
+
+type MemoryStorage struct {
+	isClosed bool
+	chunks map[apis.ChunkNum]map[apis.Version][]byte
+	latest map[apis.ChunkNum]apis.Version
+}
+
 // Creates an in-memory-only location to store data, and construct an interface by which a chunkserver can store chunks
 func ConfigureMemoryStorage() (ChunkStorage, error) {
-	panic("unimplemented")
+	return &MemoryStorage{
+		chunks: map[apis.ChunkNum]map[apis.Version][]byte{},
+		latest: map[apis.ChunkNum]apis.Version{},
+	}, nil
+}
+
+func (m *MemoryStorage) assertOpen() {
+	if m.isClosed {
+		panic("attempt to use closed MemoryStorage")
+	}
+}
+
+func (m *MemoryStorage) ListChunksWithData() ([]apis.ChunkNum, error) {
+	m.assertOpen()
+	result := make([]apis.ChunkNum, 0, len(m.chunks))
+	for k, v := range m.chunks {
+		if len(v) > 0 {
+			result = append(result, k)
+		}
+	}
+	return result, nil
+}
+
+func (m *MemoryStorage) ListVersions(chunk apis.ChunkNum) ([]apis.Version, error) {
+	m.assertOpen()
+	versionMap := m.chunks[chunk]
+	if versionMap == nil {
+		return nil, nil
+	}
+	result := make([]apis.Version, 0, len(versionMap))
+	for k, _ := range versionMap {
+		result = append(result, k)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i] < result[j]
+	})
+	return result, nil
+}
+
+func (m *MemoryStorage) ReadVersion(chunk apis.ChunkNum, version apis.Version) ([]byte, error) {
+	m.assertOpen()
+	if versionMap := m.chunks[chunk]; versionMap != nil {
+		if data, found := versionMap[version]; found {
+			ndata := make([]byte, len(data))
+			copy(ndata, data)
+			return ndata, nil
+		}
+	}
+	return nil, fmt.Errorf("no such chunk/version combination: %d/%d", chunk, version)
+}
+
+func (m *MemoryStorage) WriteVersion(chunk apis.ChunkNum, version apis.Version, data []byte) error {
+	m.assertOpen()
+	if apis.Length(len(data)) > apis.MaxChunkSize {
+		return fmt.Errorf("chunk is too large: %d/%s = data[%d]", chunk, version, len(data))
+	}
+	versionMap := m.chunks[chunk]
+	if versionMap == nil {
+		versionMap = map[apis.Version][]byte{}
+		m.chunks[chunk] = versionMap
+	}
+	existing, exists := versionMap[version]
+	if exists {
+		return fmt.Errorf("chunk/version combination already exists: %d/%d = data[%d]", chunk, version, len(existing))
+	}
+	ndata := make([]byte, len(data))
+	copy(ndata, data)
+	versionMap[version] = ndata
+	return nil
+}
+
+func (m *MemoryStorage) DeleteVersion(chunk apis.ChunkNum, version apis.Version) error {
+	m.assertOpen()
+	versionMap := m.chunks[chunk]
+	if versionMap == nil {
+		return fmt.Errorf("chunk/version combination does not exist: %d/%d", chunk, version)
+	}
+	_, exists := versionMap[version]
+	if !exists {
+		return fmt.Errorf("chunk/version combination does not exist: %d/%d", chunk, version)
+	}
+	delete(versionMap, version)
+	return nil
+}
+
+func (m *MemoryStorage) ListChunksWithLatest() ([]apis.ChunkNum, error) {
+	m.assertOpen()
+	result := make([]apis.ChunkNum, 0, len(m.latest))
+	for k, _ := range m.latest {
+		result = append(result, k)
+	}
+	return result, nil
+}
+
+func (m *MemoryStorage) GetLatestVersion(chunk apis.ChunkNum) (apis.Version, error) {
+	m.assertOpen()
+	if version, found := m.latest[chunk]; found {
+		return version, nil
+	}
+	return 0, fmt.Errorf("no latest version for chunk: %d", chunk)
+}
+
+func (m *MemoryStorage) SetLatestVersion(chunk apis.ChunkNum, latest apis.Version) error {
+	m.assertOpen()
+	m.latest[chunk] = latest
+	return nil
+}
+
+func (m *MemoryStorage) DeleteLatestVersion(chunk apis.ChunkNum) error {
+	m.assertOpen()
+	_, found := m.latest[chunk]
+	if found {
+		delete(m.latest, chunk)
+		return nil
+	} else {
+		return fmt.Errorf("cannot delete nonexistent latest version for chunk: %d", chunk)
+	}
+}
+
+func (m *MemoryStorage) Close() {
+	m.chunks = nil
+	m.latest = nil
+	m.isClosed = true
 }

--- a/src/zircon/chunkserver/storage/test/chunk.go
+++ b/src/zircon/chunkserver/storage/test/chunk.go
@@ -22,7 +22,8 @@ func sortChunkNums(chunks []apis.ChunkNum) {
 }
 
 // just for the chunk part, not for the version part
-func TestChunkStorage(openStorage func() storage.ChunkStorage, resetStorage func(), t *testing.T) {
+func TestChunkStorage(openStorage func() storage.ChunkStorage, closeStorage func(storage.ChunkStorage),
+					  resetStorage func(), t *testing.T) {
 	assert := testifyAssert.New(t)
 
 	var s storage.ChunkStorage = nil
@@ -33,7 +34,7 @@ func TestChunkStorage(openStorage func() storage.ChunkStorage, resetStorage func
 		s = openStorage()
 		defer func() {
 			if s != nil {
-				s.Close()
+				closeStorage(s)
 				s = nil
 			}
 		}()
@@ -41,7 +42,7 @@ func TestChunkStorage(openStorage func() storage.ChunkStorage, resetStorage func
 	}
 
 	reopen := func() {
-		s.Close()
+		closeStorage(s)
 		// no reset
 		s = openStorage()
 	}
@@ -237,10 +238,10 @@ func TestChunkStorage(openStorage func() storage.ChunkStorage, resetStorage func
 
 		data, err := s.ReadVersion(70, 100)
 		assert.NoError(err)
-		assert.Equal(apis.MaxChunkSize, len(data))
-		assert.Equal(152, data[len(data) - 1])
+		assert.Equal(apis.MaxChunkSize, apis.Length(len(data)))
+		assert.Equal(uint8(152), data[len(data) - 1])
 		data[len(data) - 1] = 0
-		assert.Equal(152, write[len(write) - 1])
+		assert.Equal(uint8(152), write[len(write) - 1])
 		assert.Empty(stripTrailingZeroes(data))
 	})
 

--- a/src/zircon/chunkserver/storage/test/storage_test.go
+++ b/src/zircon/chunkserver/storage/test/storage_test.go
@@ -14,13 +14,15 @@ func TestMemoryStorage(t *testing.T) {
 	openStorage := func() storage.ChunkStorage {
 		return mem
 	}
+	closeStorage := func(_ storage.ChunkStorage) {} // do nothing; memory would be wiped.
 	resetStorage := func() {
+		mem.Close()
 		newmem, err := storage.ConfigureMemoryStorage()
 		require.NoError(t, err)
 		mem = newmem
 	}
-	TestChunkStorage(openStorage, resetStorage, t)
-	TestVersionStorage(openStorage, resetStorage, t)
+	TestChunkStorage(openStorage, closeStorage, resetStorage, t)
+	TestVersionStorage(openStorage, closeStorage, resetStorage, t)
 }
 
 func TestFilesystemStorage(t *testing.T) {
@@ -39,12 +41,15 @@ func TestFilesystemStorage(t *testing.T) {
 		require.NoError(t, err)
 		return cs
 	}
+	closeStorage := func(storage storage.ChunkStorage) {
+		storage.Close()
+	}
 	resetStorage := func() {
 		require.NoError(t, os.RemoveAll(working))
 		require.NoError(t, os.Mkdir(working, 0755))
 	}
-	TestChunkStorage(openStorage, resetStorage, t)
-	TestVersionStorage(openStorage, resetStorage, t)
+	TestChunkStorage(openStorage, closeStorage, resetStorage, t)
+	TestVersionStorage(openStorage, closeStorage, resetStorage, t)
 }
 
 /*
@@ -52,6 +57,9 @@ func TestBlockStorage(t *testing.T) {
 	// TODO once we figure out how to make test block devices
 	openStorage := func() storage.ChunkStorage {
 
+	}
+	closeStorage := func(storage storage.ChunkStorage) {
+		storage.Close()
 	}
 	resetStorage := func() {
 

--- a/src/zircon/chunkserver/storage/test/version.go
+++ b/src/zircon/chunkserver/storage/test/version.go
@@ -8,7 +8,8 @@ import (
 )
 
 // just for the chunk part, not for the version part
-func TestVersionStorage(openStorage func() storage.ChunkStorage, resetStorage func(), t *testing.T) {
+func TestVersionStorage(openStorage func() storage.ChunkStorage, closeStorage func(storage.ChunkStorage),
+	 					resetStorage func(), t *testing.T) {
 	assert := testifyAssert.New(t)
 
 	var s storage.ChunkStorage = nil
@@ -19,7 +20,7 @@ func TestVersionStorage(openStorage func() storage.ChunkStorage, resetStorage fu
 		s = openStorage()
 		defer func() {
 			if s != nil {
-				s.Close()
+				closeStorage(s)
 				s = nil
 			}
 		}()
@@ -27,7 +28,7 @@ func TestVersionStorage(openStorage func() storage.ChunkStorage, resetStorage fu
 	}
 
 	reopen := func() {
-		s.Close()
+		closeStorage(s)
 		// no reset
 		s = openStorage()
 	}
@@ -57,7 +58,7 @@ func TestVersionStorage(openStorage func() storage.ChunkStorage, resetStorage fu
 
 		data, err := s.GetLatestVersion(71)
 		assert.NoError(err)
-		assert.Equal(3, data)
+		assert.Equal(apis.Version(3), data)
 	})
 
 	test("write single version corrolaries", func() {
@@ -85,7 +86,7 @@ func TestVersionStorage(openStorage func() storage.ChunkStorage, resetStorage fu
 
 		data, err := s.GetLatestVersion(71)
 		assert.NoError(err)
-		assert.Equal(3, data)
+		assert.Equal(apis.Version(3), data)
 	})
 
 	test("updating versions", func() {
@@ -94,7 +95,7 @@ func TestVersionStorage(openStorage func() storage.ChunkStorage, resetStorage fu
 
 		data, err := s.GetLatestVersion(71)
 		assert.NoError(err)
-		assert.Equal(3, data)
+		assert.Equal(apis.Version(3), data)
 
 		assert.NoError(s.SetLatestVersion(72, 6))
 		assert.NoError(s.SetLatestVersion(71, 2))
@@ -106,11 +107,11 @@ func TestVersionStorage(openStorage func() storage.ChunkStorage, resetStorage fu
 
 		data, err = s.GetLatestVersion(71)
 		assert.NoError(err)
-		assert.Equal(2, data)
+		assert.Equal(apis.Version(2), data)
 
 		data, err = s.GetLatestVersion(72)
 		assert.NoError(err)
-		assert.Equal(6, data)
+		assert.Equal(apis.Version(6), data)
 	})
 
 	test("updating versions with durability", func() {
@@ -121,7 +122,7 @@ func TestVersionStorage(openStorage func() storage.ChunkStorage, resetStorage fu
 
 		data, err := s.GetLatestVersion(71)
 		assert.NoError(err)
-		assert.Equal(3, data)
+		assert.Equal(apis.Version(3), data)
 
 		assert.NoError(s.SetLatestVersion(72, 6))
 		assert.NoError(s.SetLatestVersion(71, 2))
@@ -133,11 +134,11 @@ func TestVersionStorage(openStorage func() storage.ChunkStorage, resetStorage fu
 
 		data, err = s.GetLatestVersion(71)
 		assert.NoError(err)
-		assert.Equal(2, data)
+		assert.Equal(apis.Version(2), data)
 
 		data, err = s.GetLatestVersion(72)
 		assert.NoError(err)
-		assert.Equal(6, data)
+		assert.Equal(apis.Version(6), data)
 	})
 
 	test("delete subset of versions", func() {


### PR DESCRIPTION
Also fixes some of the tests. This implementation of chunkstorage passes all of the previously defined tests.